### PR TITLE
Workload Identity support

### DIFF
--- a/src/components/Builder/KubernetesCluster/KubernetesCluster/index.tsx
+++ b/src/components/Builder/KubernetesCluster/KubernetesCluster/index.tsx
@@ -12,6 +12,7 @@ import DefaultNodePool from "../Nodepools/DefaultNodepool/DefaultNodepool";
 import PrivateCluster from "../PrivateCluster";
 import UserDefinedRouting from "../UserDefinedRouting";
 import Version from "../Version";
+import WorkloadIdentity from "../WorkloadIdentity";
 
 export default function KubernetesCluster() {
 	const { lab } = useGlobalStateContext();
@@ -47,6 +48,7 @@ export default function KubernetesCluster() {
 							<Calico index={index} />
 							<NetworkPluginMode index={index} />
 							<UserDefinedRouting index={index} />
+							<WorkloadIdentity index={index} />
 						</div>
 					</Container>
 					<Container

--- a/src/components/Builder/KubernetesCluster/WorkloadIdentity/index.tsx
+++ b/src/components/Builder/KubernetesCluster/WorkloadIdentity/index.tsx
@@ -1,0 +1,46 @@
+import { useContext } from "react";
+import { useSetLogs } from "../../../../hooks/useLogs";
+import { useGlobalStateContext } from "../../../Context/GlobalStateContext";
+import { WebSocketContext } from "../../../Context/WebSocketContext";
+import Checkbox from "../../../UserInterfaceComponents/Checkbox";
+
+type Props = { index: number };
+
+export default function WorkloadIdentity({ index }: Props) {
+  const { actionStatus } = useContext(WebSocketContext);
+  const { mutate: setLogs } = useSetLogs();
+  const { lab, setLab } = useGlobalStateContext();
+
+  const newLab = structuredClone(lab); //shallow copy of lab
+  const cluster = newLab?.template?.kubernetesClusters[index];
+
+  // Handle checkbox change
+  const handleOnChange = () => {
+    const newLab = structuredClone(lab);
+    const cluster = newLab?.template?.kubernetesClusters[index];
+
+    if (cluster?.workloadIdentityEnabled !== undefined && newLab !== undefined) {
+      // we have to set workloadIdentityEnabled and oidcIssuerEnabled
+      // to the same value
+      cluster.workloadIdentityEnabled = !cluster.workloadIdentityEnabled;
+      cluster.oidcIssuerEnabled = cluster.workloadIdentityEnabled;
+      !actionStatus.inProgress &&
+        setLogs({ logs: JSON.stringify(newLab?.template, null, 4) });
+      setLab(newLab);
+    }
+  };
+
+  // Determine checked and disabled states
+  const checked = cluster?.workloadIdentityEnabled ?? false;
+  const disabled = !cluster;
+
+  return lab?.template ? (
+    <Checkbox
+      id="toggle-workload-identity"
+      label="Workload Identity"
+      checked={checked}
+      disabled={disabled}
+      handleOnChange={handleOnChange}
+    />
+  ) : null;
+}

--- a/src/dataStructures.ts
+++ b/src/dataStructures.ts
@@ -127,8 +127,8 @@ export type TfvarKubernetesClusterType = {
 	networkPluginMode: "Overlay" | "null";
 	outboundType: "loadBalancer" | "userDefinedRouting";
 	privateClusterEnabled: "true" | "false";
-	workloadIdentityEnabled: "true" | "false";
-	oidcIssuerEnabled: "true" | "false";
+	workloadIdentityEnabled: boolean;
+	oidcIssuerEnabled: boolean;
 	addons: TfvarAddonsType;
 	defaultNodePool: TfvarDefaultNodepoolType;
 };

--- a/src/dataStructures.ts
+++ b/src/dataStructures.ts
@@ -127,6 +127,8 @@ export type TfvarKubernetesClusterType = {
 	networkPluginMode: "Overlay" | "null";
 	outboundType: "loadBalancer" | "userDefinedRouting";
 	privateClusterEnabled: "true" | "false";
+	workloadIdentityEnabled: boolean;
+	oidcIssuerEnabled: boolean;
 	addons: TfvarAddonsType;
 	defaultNodePool: TfvarDefaultNodepoolType;
 };

--- a/src/dataStructures.ts
+++ b/src/dataStructures.ts
@@ -127,8 +127,8 @@ export type TfvarKubernetesClusterType = {
 	networkPluginMode: "Overlay" | "null";
 	outboundType: "loadBalancer" | "userDefinedRouting";
 	privateClusterEnabled: "true" | "false";
-	workloadIdentityEnabled: boolean;
-	oidcIssuerEnabled: boolean;
+	workloadIdentityEnabled: "true" | "false";
+	oidcIssuerEnabled: "true" | "false";
 	addons: TfvarAddonsType;
 	defaultNodePool: TfvarDefaultNodepoolType;
 };


### PR DESCRIPTION
Adding UI updates to pair with vermacodes/one-click-aks-server#4.

It's a top-level toggle that handles both OIDC issuer and workload identity. It might be worth breaking this out to separate toggles if there's value in enabling OIDC issuer without tying it into the Azure Workload Identity offering (third party OIDC).