### PR TITLE
Add tooltip message for disabled Jump Server checkbox based on virtua…

### DIFF
--- a/src/components/Builder/VirtualMachine/index.tsx
+++ b/src/components/Builder/VirtualMachine/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { getDefaultTfvarConfig } from "../../../defaults";
 import { useSetLogs } from "../../../hooks/useLogs";
 import { useGlobalStateContext } from "../../Context/GlobalStateContext";
@@ -28,6 +28,19 @@ export default function VirtualMachine() {
 		}
 	};
 
+	useEffect(() => {
+		if (
+			lab &&
+			lab.template &&
+			lab.template.virtualNetworks.length === 0 &&
+			tooltipMessage !== noVirtualNetworksMessage
+		) {
+			setTooltipMessage(noVirtualNetworksMessage);
+		} else if (lab && lab.template && lab.template.virtualNetworks.length > 0 && tooltipMessage) {
+			setTooltipMessage("");
+		}
+	}, [lab, tooltipMessage]);
+
 	// Define the checked state
 	const checked = (lab?.template?.jumpservers?.length ?? 0) > 0;
 
@@ -35,14 +48,6 @@ export default function VirtualMachine() {
 	var disabled: boolean = false;
 	if (lab && lab.template && lab.template.virtualNetworks.length === 0) {
 		disabled = true;
-	}
-
-	if (lab && lab.template && lab.template.virtualNetworks.length === 0 && tooltipMessage !== noVirtualNetworksMessage) {
-		setTooltipMessage(noVirtualNetworksMessage);
-	}
-
-	if (lab && lab.template && lab.template.virtualNetworks.length > 0 && tooltipMessage) {
-		setTooltipMessage("");
 	}
 
 	return lab?.template ? (

--- a/src/components/Builder/VirtualMachine/index.tsx
+++ b/src/components/Builder/VirtualMachine/index.tsx
@@ -45,7 +45,7 @@ export default function VirtualMachine() {
 	const checked = (lab?.template?.jumpservers?.length ?? 0) > 0;
 
 	// Define the disabled state
-	var disabled: boolean = false;
+	let disabled: boolean = false;
 	if (lab && lab.template && lab.template.virtualNetworks.length === 0) {
 		disabled = true;
 	}


### PR DESCRIPTION
This pull request introduces changes to the `VirtualMachine` component in the `src/components/Builder/VirtualMachine/index.tsx` file. The main focus of the changes is to enhance the functionality and user experience by adding a tooltip message and refining the handling of the disabled state for the checkbox.

Enhancements to `VirtualMachine` component:

* Added a `tooltipMessage` state to display messages to the user. (`[src/components/Builder/VirtualMachine/index.tsxL1-R55](diffhunk://#diff-724ddfb38dc67d34e18464dd011e133c835c77d9e8f20ef90a4d9ecf4ebe632cL1-R55)`)
* Updated the `handleOnChange` function to use a more concise format for toggling jump servers. (`[src/components/Builder/VirtualMachine/index.tsxL1-R55](diffhunk://#diff-724ddfb38dc67d34e18464dd011e133c835c77d9e8f20ef90a4d9ecf4ebe632cL1-R55)`)
* Introduced logic to set the `disabled` state based on the presence of virtual networks in the `lab` template. (`[src/components/Builder/VirtualMachine/index.tsxL1-R55](diffhunk://#diff-724ddfb38dc67d34e18464dd011e133c835c77d9e8f20ef90a4d9ecf4ebe632cL1-R55)`)
* Implemented conditional updates to the `tooltipMessage` based on the state of virtual networks in the `lab` template. (`[src/components/Builder/VirtualMachine/index.tsxL1-R55](diffhunk://#diff-724ddfb38dc67d34e18464dd011e133c835c77d9e8f20ef90a4d9ecf4ebe632cL1-R55)`)
* Passed the `tooltipMessage` prop to the `Checkbox` component to display relevant messages to the user. (`[src/components/Builder/VirtualMachine/index.tsxL1-R55](diffhunk://#diff-724ddfb38dc67d34e18464dd011e133c835c77d9e8f20ef90a4d9ecf4ebe632cL1-R55)`)